### PR TITLE
Twist limiter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ include_directories(
 # add_dependencies(iarc7_motion ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Declare a C++ executable
-add_executable(low_level_motion_controller src/LowLevelMotionController.cpp src/FeedForwardPid.cpp src/QuadVelocityController.cpp)
+add_executable(low_level_motion_controller src/LowLevelMotionController.cpp src/FeedForwardPid.cpp src/QuadVelocityController.cpp src/QuadTwistRequestLimiter.cpp)
 
 ## Add cmake target dependencies of the executable
 ## same as for the library above

--- a/include/iarc7_motion/QuadTwistRequestLimiter.hpp
+++ b/include/iarc7_motion/QuadTwistRequestLimiter.hpp
@@ -32,13 +32,13 @@ namespace Iarc7Motion
         QuadTwistRequestLimiter(const QuadTwistRequestLimiter& rhs) = delete;
         QuadTwistRequestLimiter& operator=(const QuadTwistRequestLimiter& rhs) = delete;
 
-        TwistStamped limitTwist(const TwistStamped& twist);
+        void limitTwist(TwistStamped& input_twist);
 
     private:
 
-        static double velocityLimit(double start, double end, double max, ros::Duration& delta, char const * axis);
-        static double minLimit(double request, double min, char const * axis);
-        static double maxLimit(double request, double max, char const * axis);
+        static void velocityLimit(double& request, const double old, const double max, const ros::Duration& delta, char const * axis);
+        static void minLimit(double& request, const double min, char const * axis);
+        static void maxLimit(double& request, const double max, char const * axis);
 
         Twist minTwist_;
         Twist maxTwist_;

--- a/include/iarc7_motion/QuadTwistRequestLimiter.hpp
+++ b/include/iarc7_motion/QuadTwistRequestLimiter.hpp
@@ -1,0 +1,49 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Twist Limiter
+//
+// Limits the rate of change of a twist and min/max values
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef QUAD_TWIST_LIMITER_HPP
+#define QUAD_TWIST_LIMITER_HPP
+
+#include <ros/ros.h>
+#include "geometry_msgs/Twist.h"
+#include "geometry_msgs/TwistStamped.h"
+
+using geometry_msgs::TwistStamped;
+using geometry_msgs::Twist;
+
+namespace Iarc7Motion
+{
+
+    class QuadTwistRequestLimiter
+    {
+    public:
+        QuadTwistRequestLimiter() = delete;
+
+        QuadTwistRequestLimiter(Twist minTwist, Twist maxTwist, Twist maxChange);
+
+        ~QuadTwistRequestLimiter() = default;
+
+        // Don't allow the copy constructor or assignment.
+        QuadTwistRequestLimiter(const QuadTwistRequestLimiter& rhs) = delete;
+        QuadTwistRequestLimiter& operator=(const QuadTwistRequestLimiter& rhs) = delete;
+
+        TwistStamped limitTwist(const TwistStamped& twist);
+
+    private:
+
+        static double velocityLimit(double start, double end, double max, ros::Duration& delta, char const * axis);
+        static double minLimit(double request, double min, char const * axis);
+        static double maxLimit(double request, double max, char const * axis);
+
+        Twist minTwist_;
+        Twist maxTwist_;
+        Twist maxTwistChange_;
+    };
+} // End namespace Iarc7Motion
+
+#endif // QUAD_TWIST_LIMITER_HPP

--- a/include/iarc7_motion/QuadTwistRequestLimiter.hpp
+++ b/include/iarc7_motion/QuadTwistRequestLimiter.hpp
@@ -19,31 +19,32 @@ using geometry_msgs::Twist;
 namespace Iarc7Motion
 {
 
-    class QuadTwistRequestLimiter
-    {
-    public:
-        QuadTwistRequestLimiter() = delete;
+class QuadTwistRequestLimiter
+{
+public:
+    QuadTwistRequestLimiter() = delete;
 
-        QuadTwistRequestLimiter(Twist minTwist, Twist maxTwist, Twist maxChange);
+    QuadTwistRequestLimiter(Twist minTwist, Twist maxTwist, Twist maxChange);
 
-        ~QuadTwistRequestLimiter() = default;
+    ~QuadTwistRequestLimiter() = default;
 
-        // Don't allow the copy constructor or assignment.
-        QuadTwistRequestLimiter(const QuadTwistRequestLimiter& rhs) = delete;
-        QuadTwistRequestLimiter& operator=(const QuadTwistRequestLimiter& rhs) = delete;
+    // Don't allow the copy constructor or assignment.
+    QuadTwistRequestLimiter(const QuadTwistRequestLimiter& rhs) = delete;
+    QuadTwistRequestLimiter& operator=(const QuadTwistRequestLimiter& rhs) = delete;
 
-        void limitTwist(TwistStamped& input_twist);
+    void limitTwist(TwistStamped& input_twist);
 
-    private:
+private:
 
-        static void velocityLimit(double& request, const double old, const double max, const ros::Duration& delta, char const * axis);
-        static void minLimit(double& request, const double min, char const * axis);
-        static void maxLimit(double& request, const double max, char const * axis);
+    static void velocityLimit(double& request, const double old, const double max, const ros::Duration& delta, char const * axis);
+    static void minLimit(double& request, const double min, char const * axis);
+    static void maxLimit(double& request, const double max, char const * axis);
 
-        Twist minTwist_;
-        Twist maxTwist_;
-        Twist maxTwistChange_;
-    };
+    Twist minTwist_;
+    Twist maxTwist_;
+    Twist maxTwistChange_;
+};
+
 } // End namespace Iarc7Motion
 
 #endif // QUAD_TWIST_LIMITER_HPP

--- a/include/iarc7_motion/QuadVelocityController.hpp
+++ b/include/iarc7_motion/QuadVelocityController.hpp
@@ -18,7 +18,7 @@
 #include "geometry_msgs/TwistStamped.h"
 #include "geometry_msgs/Vector3.h"
 #include "iarc7_msgs/Float64Stamped.h"
-
+#include "iarc7_msgs/OrientationThrottleStamped.h"
 
 namespace Iarc7Motion
 {
@@ -43,6 +43,8 @@ namespace Iarc7Motion
     private:
 
         bool getVelocities(geometry_msgs::Vector3& return_velocities);
+
+        static void limitUavCommand(iarc7_msgs::OrientationThrottleStamped& uav_command);
 
         ros::NodeHandle& nh_;
 

--- a/include/iarc7_motion/QuadVelocityController.hpp
+++ b/include/iarc7_motion/QuadVelocityController.hpp
@@ -36,7 +36,7 @@ namespace Iarc7Motion
         QuadVelocityController(const QuadVelocityController& rhs) = delete;
         QuadVelocityController& operator=(const QuadVelocityController& rhs) = delete;
 
-        void update();
+        iarc7_msgs::OrientationThrottleStamped update();
 
         void setTargetVelocity(geometry_msgs::Twist twist);
 
@@ -47,8 +47,6 @@ namespace Iarc7Motion
         static void limitUavCommand(iarc7_msgs::OrientationThrottleStamped& uav_command);
 
         ros::NodeHandle& nh_;
-
-        ros::Publisher uav_control_;
 
         tf2_ros::Buffer tfBuffer_;
         tf2_ros::TransformListener tfListener_;

--- a/src/LowLevelMotionController.cpp
+++ b/src/LowLevelMotionController.cpp
@@ -7,10 +7,41 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #include <ros/ros.h>
+
 #include "iarc7_motion/AccelerationPlanner.hpp"
 #include "iarc7_motion/QuadVelocityController.hpp"
+#include "iarc7_motion/QuadTwistRequestLimiter.hpp"
+
+#include "geometry_msgs/Twist.h"
+#include "geometry_msgs/TwistStamped.h"
 
 using namespace Iarc7Motion;
+using geometry_msgs::TwistStamped;
+using geometry_msgs::Twist;
+
+// This is a helper function that will limit a uav command using the twist limiter
+// It will eventually no longer be needed when the quad velocity controller is converted to use twists
+void limitUavCommand(QuadTwistRequestLimiter& limiter, iarc7_msgs::OrientationThrottleStamped& uav_command)
+{
+    TwistStamped uav_twist_stamped;
+    Twist& uav_twist = uav_twist_stamped.twist;
+
+    // Convert from uav command to twist
+    uav_twist_stamped.header.stamp = uav_command.header.stamp;
+    uav_twist.linear.z  = uav_command.throttle;
+    uav_twist.angular.y = uav_command.data.pitch;
+    uav_twist.angular.x = uav_command.data.roll;
+    uav_twist.angular.z = uav_command.data.yaw;
+
+    limiter.limitTwist(uav_twist_stamped);
+
+    // Copy the twist to the uav command
+    uav_command.header.stamp = uav_twist_stamped.header.stamp;
+    uav_command.throttle     = uav_twist.linear.z;
+    uav_command.data.pitch   = uav_twist.angular.y;
+    uav_command.data.roll    = uav_twist.angular.x;
+    uav_command.data.yaw     = uav_twist.angular.z;
+}
 
 int main(int argc, char **argv)
 {
@@ -24,9 +55,46 @@ int main(int argc, char **argv)
 
     AccelerationPlanner<QuadVelocityController> accelerationPlanner(nh, quadController);
 
+    ros::Publisher uav_control_ = nh.advertise<iarc7_msgs::OrientationThrottleStamped>("uav_direction_command", 50);
+
+    // Check for empty uav_control_ as per http://wiki.ros.org/roscpp/Overview/Publishers%20and%20Subscribers
+    // section 1
+    if(!uav_control_)
+    {
+        ROS_ASSERT("Could not create uav_control_ publisher");
+    }
+
+    // Limit the twist, this will be cleaned up when we switch to rosparam
+    Twist min;
+    min.linear.z  = 0.0;
+    min.angular.y = -20.0;
+    min.angular.x = -20.0;
+    min.angular.z = -20.0;
+
+    Twist max;
+    min.linear.z  = 100.0;
+    min.angular.y = 20.0;
+    min.angular.x = 20.0;
+    min.angular.z = 20.0;
+
+    Twist max_rate;
+    min.linear.z  = 100.0;
+    min.angular.y = 20.0;
+    min.angular.x = 20.0;
+    min.angular.z = 20.0;
+
+    QuadTwistRequestLimiter limiter(min, max, max_rate);
+
     while(ros::ok())
     {
-        quadController.update();
+        iarc7_msgs::OrientationThrottleStamped uav_command = quadController.update();
+
+        // Limit the uav command
+        limitUavCommand(limiter, uav_command);
+
+        // Publish the desired angles and throttle
+        uav_control_.publish(uav_command);
+
         ros::spinOnce();
     }
 

--- a/src/LowLevelMotionController.cpp
+++ b/src/LowLevelMotionController.cpp
@@ -59,10 +59,7 @@ int main(int argc, char **argv)
 
     // Check for empty uav_control_ as per http://wiki.ros.org/roscpp/Overview/Publishers%20and%20Subscribers
     // section 1
-    if(!uav_control_)
-    {
-        ROS_ASSERT("Could not create uav_control_ publisher");
-    }
+    ROS_ASSERT_MSG(uav_control_, "Could not create uav_direction_command publisher");
 
     // Limit the twist, this will be cleaned up when we switch to rosparam
     Twist min;
@@ -72,16 +69,16 @@ int main(int argc, char **argv)
     min.angular.z = -20.0;
 
     Twist max;
-    min.linear.z  = 100.0;
-    min.angular.y = 20.0;
-    min.angular.x = 20.0;
-    min.angular.z = 20.0;
+    max.linear.z  = 100.0;
+    max.angular.y = 20.0;
+    max.angular.x = 20.0;
+    max.angular.z = 20.0;
 
     Twist max_rate;
-    min.linear.z  = 100.0;
-    min.angular.y = 20.0;
-    min.angular.x = 20.0;
-    min.angular.z = 20.0;
+    max_rate.linear.z  = 100.0;
+    max_rate.angular.y = 20.0;
+    max_rate.angular.x = 20.0;
+    max_rate.angular.z = 20.0;
 
     QuadTwistRequestLimiter limiter(min, max, max_rate);
 

--- a/src/QuadTwistRequestLimiter.cpp
+++ b/src/QuadTwistRequestLimiter.cpp
@@ -19,85 +19,73 @@ maxTwistChange_(maxChange)
 }
 
 // TODO sanity check these values
-TwistStamped QuadTwistRequestLimiter::limitTwist(const TwistStamped& twist)
+void QuadTwistRequestLimiter::limitTwist(TwistStamped& input_twist)
 {
     static TwistStamped last_twist;
     static bool run_once{false};
 
-    TwistStamped returnTwist;
-
-    returnTwist.header.stamp = twist.header.stamp;
-
     if(!run_once)
     {
-        last_twist = twist;
+        last_twist = input_twist;
         run_once = true;
+
         // Return empty TwistStamped
-        return TwistStamped();
+        TwistStamped return_twist;
+        return_twist.header.stamp = input_twist.header.stamp;
+        input_twist = return_twist;
+        return;
     }
 
     // Limit the rates
-    ros::Duration delta = twist.header.stamp - last_twist.header.stamp;
-    returnTwist.twist.linear.z  = velocityLimit(last_twist.twist.linear.z,  twist.twist.linear.z,  maxTwistChange_.linear.z,  delta, "Thrust");
+    ros::Duration delta = input_twist.header.stamp - last_twist.header.stamp;
+    velocityLimit(input_twist.twist.linear.z,  last_twist.twist.linear.z,  maxTwistChange_.linear.z,  delta, "Thrust");
     // If X extends towards the front of the quad than rotating around the X axis is pitch
-    returnTwist.twist.angular.y = velocityLimit(last_twist.twist.angular.y, twist.twist.angular.y, maxTwistChange_.angular.y, delta, "Pitch");
+    velocityLimit(input_twist.twist.angular.y, last_twist.twist.angular.y, maxTwistChange_.angular.y, delta, "Pitch");
     // If X extends towards the front of the quad than rotating around the X axis is roll
-    returnTwist.twist.angular.x = velocityLimit(last_twist.twist.angular.x, twist.twist.angular.x, maxTwistChange_.angular.x, delta, "Roll");
+    velocityLimit(input_twist.twist.angular.x, last_twist.twist.angular.x, maxTwistChange_.angular.x, delta, "Roll");
     // If X extends towards the front of the quad than rotating around the Z axis is yaw
-    returnTwist.twist.angular.z = velocityLimit(last_twist.twist.angular.z, twist.twist.angular.z, maxTwistChange_.angular.z, delta, "Yaw");
+    velocityLimit(input_twist.twist.angular.z, last_twist.twist.angular.z, maxTwistChange_.angular.z, delta, "Yaw");
 
     // Limit the max
-    returnTwist.twist.linear.z  = maxLimit(returnTwist.twist.linear.z,  maxTwist_.linear.z,  "Thrust");
-    returnTwist.twist.angular.y = maxLimit(returnTwist.twist.angular.y, maxTwist_.angular.y, "Pitch");
-    returnTwist.twist.angular.x = maxLimit(returnTwist.twist.angular.x, maxTwist_.angular.x, "Roll");
-    returnTwist.twist.angular.z = maxLimit(returnTwist.twist.angular.z, maxTwist_.angular.z, "Yaw");
+    maxLimit(input_twist.twist.linear.z,  maxTwist_.linear.z,  "Thrust");
+    maxLimit(input_twist.twist.angular.y, maxTwist_.angular.y, "Pitch");
+    maxLimit(input_twist.twist.angular.x, maxTwist_.angular.x, "Roll");
+    maxLimit(input_twist.twist.angular.z, maxTwist_.angular.z, "Yaw");
 
     // Limit the min
-    returnTwist.twist.linear.z  = minLimit(returnTwist.twist.linear.z,  minTwist_.linear.z,  "Thrust");
-    returnTwist.twist.angular.y = minLimit(returnTwist.twist.angular.y, minTwist_.angular.y, "Pitch");
-    returnTwist.twist.angular.x = minLimit(returnTwist.twist.angular.x, minTwist_.angular.x, "Roll");
-    returnTwist.twist.angular.z = minLimit(returnTwist.twist.angular.z, minTwist_.angular.z, "Yaw");
-
-    return returnTwist;
+    minLimit(input_twist.twist.linear.z,  minTwist_.linear.z,  "Thrust");
+    minLimit(input_twist.twist.angular.y, minTwist_.angular.y, "Pitch");
+    minLimit(input_twist.twist.angular.x, minTwist_.angular.x, "Roll");
+    minLimit(input_twist.twist.angular.z, minTwist_.angular.z, "Yaw");
 }
 
-double QuadTwistRequestLimiter::velocityLimit(double start, double end, double max, ros::Duration& delta, char const * axis)
+void QuadTwistRequestLimiter::velocityLimit(double& request, const double old, const double max, const ros::Duration& delta, char const * axis)
 {
-    double velocity = (end - start) / delta.toSec();
-    double result{0.0};
+    double velocity = (request - old) / delta.toSec();
 
     if(abs(velocity) > max)
     {
-        // Multiply max by the sign of velocity
-        result = (max * ((velocity > 0) - (velocity < 0))) + start;
-        ROS_ERROR("%s rate limit reached, requested: %f given: %f", axis, result, end);
+        // result = (sign of velocity) * max_velocity + start
+        double result = (((velocity > 0) - (velocity < 0)) * max) + old;
+        ROS_ERROR("%s rate limit reached, requested: %f allowed: %f", axis, result, old);
+        request = result;
     }
-    else
-    {  
-        result = end;
-    }
-
-    return result;
 }
 
-double QuadTwistRequestLimiter::maxLimit(double request, double max, char const * axis)
+void QuadTwistRequestLimiter::maxLimit(double& request, const double max, char const * axis)
 {
     if(request > max)
     {
-        ROS_ERROR("%s max value exceeded, requested: %f given: %f", axis, request, max);
-        return max;
+        ROS_ERROR("%s max value exceeded, requested: %f allowed: %f", axis, request, max);
+        request = max;
     }
-    
-    return request;
 }
 
-double QuadTwistRequestLimiter::minLimit(double request, double min, char const * axis)
+void QuadTwistRequestLimiter::minLimit(double& request, const double min, char const * axis)
 {
     if(request < min)
     {
-        ROS_ERROR("%s min value exceeded, requested: %f given: %f", axis, request, min);
-        return min;
+        ROS_ERROR("%s min value exceeded, requested: %f allowed: %f", axis, request, min);
+        request = min;
     }
-    
-    return request;
 }

--- a/src/QuadTwistRequestLimiter.cpp
+++ b/src/QuadTwistRequestLimiter.cpp
@@ -1,0 +1,103 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Twist Limiter
+//
+// Limits the rate of change of a twist and min/max values
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include "iarc7_motion/QuadTwistRequestLimiter.hpp"
+#include <cmath>
+
+using namespace Iarc7Motion;
+QuadTwistRequestLimiter::QuadTwistRequestLimiter(Twist minTwist, Twist maxTwist, Twist maxChange) :
+minTwist_(minTwist) ,
+maxTwist_(maxTwist) ,
+maxTwistChange_(maxChange)
+{
+
+}
+
+// TODO sanity check these values
+TwistStamped QuadTwistRequestLimiter::limitTwist(const TwistStamped& twist)
+{
+    static TwistStamped last_twist;
+    static bool run_once{false};
+
+    TwistStamped returnTwist;
+
+    returnTwist.header.stamp = twist.header.stamp;
+
+    if(!run_once)
+    {
+        last_twist = twist;
+        run_once = true;
+        // Return empty TwistStamped
+        return TwistStamped();
+    }
+
+    // Limit the rates
+    ros::Duration delta = twist.header.stamp - last_twist.header.stamp;
+    returnTwist.twist.linear.z  = velocityLimit(last_twist.twist.linear.z,  twist.twist.linear.z,  maxTwistChange_.linear.z,  delta, "Thrust");
+    // If X extends towards the front of the quad than rotating around the X axis is pitch
+    returnTwist.twist.angular.y = velocityLimit(last_twist.twist.angular.y, twist.twist.angular.y, maxTwistChange_.angular.y, delta, "Pitch");
+    // If X extends towards the front of the quad than rotating around the X axis is roll
+    returnTwist.twist.angular.x = velocityLimit(last_twist.twist.angular.x, twist.twist.angular.x, maxTwistChange_.angular.x, delta, "Roll");
+    // If X extends towards the front of the quad than rotating around the Z axis is yaw
+    returnTwist.twist.angular.z = velocityLimit(last_twist.twist.angular.z, twist.twist.angular.z, maxTwistChange_.angular.z, delta, "Yaw");
+
+    // Limit the max
+    returnTwist.twist.linear.z  = maxLimit(returnTwist.twist.linear.z,  maxTwist_.linear.z,  "Thrust");
+    returnTwist.twist.angular.y = maxLimit(returnTwist.twist.angular.y, maxTwist_.angular.y, "Pitch");
+    returnTwist.twist.angular.x = maxLimit(returnTwist.twist.angular.x, maxTwist_.angular.x, "Roll");
+    returnTwist.twist.angular.z = maxLimit(returnTwist.twist.angular.z, maxTwist_.angular.z, "Yaw");
+
+    // Limit the min
+    returnTwist.twist.linear.z  = minLimit(returnTwist.twist.linear.z,  minTwist_.linear.z,  "Thrust");
+    returnTwist.twist.angular.y = minLimit(returnTwist.twist.angular.y, minTwist_.angular.y, "Pitch");
+    returnTwist.twist.angular.x = minLimit(returnTwist.twist.angular.x, minTwist_.angular.x, "Roll");
+    returnTwist.twist.angular.z = minLimit(returnTwist.twist.angular.z, minTwist_.angular.z, "Yaw");
+
+    return returnTwist;
+}
+
+double QuadTwistRequestLimiter::velocityLimit(double start, double end, double max, ros::Duration& delta, char const * axis)
+{
+    double velocity = (end - start) / delta.toSec();
+    double result{0.0};
+
+    if(abs(velocity) > max)
+    {
+        // Multiply max by the sign of velocity
+        result = (max * ((velocity > 0) - (velocity < 0))) + start;
+        ROS_ERROR("%s rate limit reached, requested: %f given: %f", axis, result, end);
+    }
+    else
+    {  
+        result = end;
+    }
+
+    return result;
+}
+
+double QuadTwistRequestLimiter::maxLimit(double request, double max, char const * axis)
+{
+    if(request > max)
+    {
+        ROS_ERROR("%s max value exceeded, requested: %f given: %f", axis, request, max);
+        return max;
+    }
+    
+    return request;
+}
+
+double QuadTwistRequestLimiter::minLimit(double request, double min, char const * axis)
+{
+    if(request < min)
+    {
+        ROS_ERROR("%s min value exceeded, requested: %f given: %f", axis, request, min);
+        return min;
+    }
+    
+    return request;
+}

--- a/src/QuadTwistRequestLimiter.cpp
+++ b/src/QuadTwistRequestLimiter.cpp
@@ -67,7 +67,7 @@ void QuadTwistRequestLimiter::velocityLimit(double& request, const double old, c
     {
         // result = (sign of velocity) * max_velocity + start
         double result = (((velocity > 0) - (velocity < 0)) * max) + old;
-        ROS_ERROR("%s rate limit reached, requested: %f allowed: %f", axis, result, old);
+        ROS_WARN("%s rate limit reached, requested: %f allowed: %f", axis, result, old);
         request = result;
     }
 }
@@ -76,7 +76,7 @@ void QuadTwistRequestLimiter::maxLimit(double& request, const double max, char c
 {
     if(request > max)
     {
-        ROS_ERROR("%s max value exceeded, requested: %f allowed: %f", axis, request, max);
+        ROS_WARN("%s max value exceeded, requested: %f allowed: %f", axis, request, max);
         request = max;
     }
 }
@@ -85,7 +85,7 @@ void QuadTwistRequestLimiter::minLimit(double& request, const double min, char c
 {
     if(request < min)
     {
-        ROS_ERROR("%s min value exceeded, requested: %f allowed: %f", axis, request, min);
+        ROS_WARN("%s min value exceeded, requested: %f allowed: %f", axis, request, min);
         request = min;
     }
 }

--- a/src/QuadVelocityController.cpp
+++ b/src/QuadVelocityController.cpp
@@ -111,7 +111,7 @@ void QuadVelocityController::limitUavCommand(iarc7_msgs::OrientationThrottleStam
     min.angular.z = 20.0;
 
     QuadTwistRequestLimiter limiter(min, max, max_rate);
-    uav_twist_stamped = limiter.limitTwist(uav_twist_stamped);
+    limiter.limitTwist(uav_twist_stamped);
 
     // Copy the twist to the uav command
     uav_command.header.stamp = uav_twist_stamped.header.stamp;


### PR DESCRIPTION
A class has been added to limit the max slew rate, min, and max requests that are made to the flight controller. QuadVelocityController was slightly refactored to remove responsibilities it shouldn't have had.

I'm using a rather ugly way to get the parameters into the new QuadTwistLimiter class however the comments explain how that will be cleaned up in the future with rosparam and switching QuadVelocityController to use twists.