### PR TITLE
Support simultaneous yaw and translation

### DIFF
--- a/include/iarc7_motion/QuadVelocityController.hpp
+++ b/include/iarc7_motion/QuadVelocityController.hpp
@@ -31,7 +31,8 @@ namespace Iarc7Motion
 
         QuadVelocityController(double thrust_pid[5],
                                double pitch_pid[5],
-                               double roll_pid[5]);
+                               double roll_pid[5],
+                               double yaw_pid[5]);
 
         ~QuadVelocityController() = default;
 
@@ -47,7 +48,7 @@ namespace Iarc7Motion
 
     private:
 
-        bool getVelocities(geometry_msgs::Vector3& return_velocities);
+        bool getVelocities(geometry_msgs::Twist& return_velocities);
 
         static void limitUavCommand(iarc7_msgs::OrientationThrottleStamped& uav_command);
 
@@ -63,9 +64,10 @@ namespace Iarc7Motion
 
         // Holds the last transform received to calculate velocities
         geometry_msgs::TransformStamped last_transform_stamped_;
+        double last_yaw_;
 
         // Holds the last valid velocity reading
-        geometry_msgs::Vector3Stamped last_velocity_stamped_;
+        geometry_msgs::TwistStamped last_velocity_stamped_;
 
         // Makes sure that we have a lastTransformStamped before returning a valid velocity
         bool ran_once_;

--- a/launch/sim_low_level_motion.launch
+++ b/launch/sim_low_level_motion.launch
@@ -1,5 +1,5 @@
 <launch>
-    <node name="low_level_motion_controller" pkg="iarc7_motion" type="low_level_motion_controller">
+    <node name="low_level_motion_controller" pkg="iarc7_motion" type="low_level_motion_controller" output="screen">
         <rosparam command="load" file="$(find iarc7_motion)/param/sim_low_level_motion.yaml" />
     </node>
 </launch>

--- a/launch/sim_low_level_motion.launch
+++ b/launch/sim_low_level_motion.launch
@@ -1,5 +1,5 @@
 <launch>
-    <node name="low_level_motion_controller" pkg="iarc7_motion" type="low_level_motion_controller" output="screen">
+    <node name="low_level_motion_controller" pkg="iarc7_motion" type="low_level_motion_controller">
         <rosparam command="load" file="$(find iarc7_motion)/param/sim_low_level_motion.yaml" />
     </node>
 </launch>

--- a/launch/sim_low_level_motion.launch
+++ b/launch/sim_low_level_motion.launch
@@ -1,5 +1,5 @@
 <launch>
     <node name="low_level_motion_controller" pkg="iarc7_motion" type="low_level_motion_controller">
-        <rosparam command="load" file="$(find iarc7_motion)/param/sim_low_level_motion.yaml" />
+        <rosparam command="load" file="$(find iarc7_motion)/param/sim_low_level_motion.yaml"/>
     </node>
 </launch>

--- a/param/low_level_motion_0.05.yaml
+++ b/param/low_level_motion_0.05.yaml
@@ -16,6 +16,12 @@ roll_d: 0.0
 roll_accumulator_max: 0.0
 roll_accumulator_min: 0.0
 
+yaw_p: 0.0
+yaw_i: 0.0
+yaw_d: 0.0
+yaw_accumulator_max: 0.0
+yaw_accumulator_min: 0.0
+
 throttle_max      : 0.0
 throttle_min      : 0.0
 throttle_max_rate : 0.0

--- a/param/sim_low_level_motion.yaml
+++ b/param/sim_low_level_motion.yaml
@@ -16,6 +16,12 @@ roll_d: 0.0
 roll_accumulator_max: 0.0
 roll_accumulator_min: 0.0
 
+yaw_p: 1.0
+yaw_i: 0.0
+yaw_d: 0.0
+yaw_accumulator_max: 0.0
+yaw_accumulator_min: 0.0
+
 throttle_max      : 100.0
 throttle_min      : 0.0
 throttle_max_rate : 100.0
@@ -28,6 +34,6 @@ roll_max          : 20.0
 roll_min          : -20.0
 roll_max_rate     : 20.0
 
-yaw_max           : 10.0
-yaw_min           : -10.0
-yaw_max_rate      : 10.0
+yaw_max           : 3.14
+yaw_min           : -3.14
+yaw_max_rate      : 3.14

--- a/scripts/waypoints_test.py
+++ b/scripts/waypoints_test.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
         # Get the yaw (z axis) rotation from the quanternion
         current_yaw = tf.transformations.euler_from_quaternion(rot)[2]
         
-        # Transform current yaw to be between 0 and 2pi
+        # Transform current yaw to be between 0 and 2pi because the points are encoded from 0 to 2pi
         if current_yaw < 0:
             current_yaw = (2.0 * math.pi) + current_yaw
 
@@ -77,6 +77,7 @@ if __name__ == '__main__':
         if abs(yaw_difference) >= 0.02:
             velocity.twist.angular.z = constrain(yaw_difference * kP_yaw, -max_yaw_vel, max_yaw_vel)
         print velocity
+        print target
 
         velocity_msg = TwistStampedArrayStamped()
         velocity_msg.header.stamp = rospy.Time.now()

--- a/scripts/waypoints_test.py
+++ b/scripts/waypoints_test.py
@@ -22,20 +22,25 @@ if __name__ == '__main__':
 
     # Target points in global (X, Y, Z) coordinates
     waypoints = [
-            (0, 0, 3),
-            (3, 0, 3),
-            (-3, 1, 4),
+            (0, 0, 3, 0 * math.pi),
+            (3, 0, 3, 1.75 * math.pi),
+            (-3, 1, 4, 0.25 * math.pi),
+            (-3, 1, 4, 1.5 * math.pi),
+            (0, 0, 5, 1 * math.pi),
+            (1, 2, 2, 1.25 * math.pi),
             ]
     waypoints_iter = iter(waypoints)
     target = next(waypoints_iter)
 
     kP = 0.5
+    kP_yaw = 0.5
     max_vel = 1
+    max_yaw_vel = 2.0 * math.pi / 3 # Max requested yaw is one rev per 3 seconds
 
     rate = rospy.Rate(30)
     while not rospy.is_shutdown():
         try:
-            (trans, rot) = tf_listener.lookupTransform('/map', '/level_quad', rospy.Time(0))
+            (trans, rot) = tf_listener.lookupTransform('/map', '/quad', rospy.Time(0))
         except tf.Exception as ex:
             rospy.logerr(ex.message)
             continue
@@ -49,6 +54,32 @@ if __name__ == '__main__':
             velocity.twist.linear.y = constrain((target[1] - trans[1]) * kP, -max_vel, max_vel)
         if abs(target[2] - trans[2]) >= 0.02:
             velocity.twist.linear.z = target[2] - trans[2]
+        
+        # Get the yaw (z axis) rotation from the quanternion
+        ysqr = rot[1] * rot[1];
+        t3 = 2.0 * (rot[3] * rot[2] + rot[0] * rot[1]);
+        t4 = 1.0 - 2.0 * (ysqr + rot[2] * rot[2]);  
+        current_yaw = math.atan2(t3, t4);
+        
+        # Constrain the output of atan2 between 0 and 2pi
+        if current_yaw < 0:
+            current_yaw = (2.0 * math.pi) + current_yaw
+
+        # Calculate the difference
+        yaw_difference = target[3] - current_yaw
+
+        # Avoid taking the long way around
+        if(yaw_difference > math.pi):
+            yaw_difference = yaw_difference - 2.0 * math.pi
+        
+        # Avoid taking the long way around
+        if(yaw_difference < -math.pi):
+            yaw_difference = yaw_difference + 2.0 * math.pi
+
+        # Finally set the desired twist velocity
+        if abs(yaw_difference) >= 0.02:
+            velocity.twist.angular.z = constrain(yaw_difference * kP_yaw, -max_yaw_vel, max_yaw_vel)
+
         print velocity
 
         velocity_msg = TwistStampedArrayStamped()
@@ -57,6 +88,7 @@ if __name__ == '__main__':
         velocity_pub.publish(velocity_msg)
 
         if math.sqrt(sum((target[i] - trans[i])**2 for i in range(3))) < 0.1:
-            target = next(waypoints_iter, target)
+            if abs(yaw_difference) < 0.05:
+                target = next(waypoints_iter, target)
 
         rate.sleep()

--- a/scripts/waypoints_test.py
+++ b/scripts/waypoints_test.py
@@ -56,7 +56,7 @@ if __name__ == '__main__':
             velocity.twist.linear.z = target[2] - trans[2]
         
         # Get the yaw (z axis) rotation from the quanternion
-        current_yaw = tf.transformations.euler_from_quaternion(rot)[2]
+        current_yaw = tf.transformations.euler_from_quaternion(rot, 'rzyx')[0]
         
         # Transform current yaw to be between 0 and 2pi because the points are encoded from 0 to 2pi
         if current_yaw < 0:

--- a/scripts/waypoints_test.py
+++ b/scripts/waypoints_test.py
@@ -56,12 +56,9 @@ if __name__ == '__main__':
             velocity.twist.linear.z = target[2] - trans[2]
         
         # Get the yaw (z axis) rotation from the quanternion
-        ysqr = rot[1] * rot[1];
-        t3 = 2.0 * (rot[3] * rot[2] + rot[0] * rot[1]);
-        t4 = 1.0 - 2.0 * (ysqr + rot[2] * rot[2]);  
-        current_yaw = math.atan2(t3, t4);
+        current_yaw = tf.transformations.euler_from_quaternion(rot)[2]
         
-        # Constrain the output of atan2 between 0 and 2pi
+        # Transform current yaw to be between 0 and 2pi
         if current_yaw < 0:
             current_yaw = (2.0 * math.pi) + current_yaw
 
@@ -71,7 +68,7 @@ if __name__ == '__main__':
         # Avoid taking the long way around
         if(yaw_difference > math.pi):
             yaw_difference = yaw_difference - 2.0 * math.pi
-        
+
         # Avoid taking the long way around
         if(yaw_difference < -math.pi):
             yaw_difference = yaw_difference + 2.0 * math.pi
@@ -79,7 +76,6 @@ if __name__ == '__main__':
         # Finally set the desired twist velocity
         if abs(yaw_difference) >= 0.02:
             velocity.twist.angular.z = constrain(yaw_difference * kP_yaw, -max_yaw_vel, max_yaw_vel)
-
         print velocity
 
         velocity_msg = TwistStampedArrayStamped()
@@ -88,7 +84,7 @@ if __name__ == '__main__':
         velocity_pub.publish(velocity_msg)
 
         if math.sqrt(sum((target[i] - trans[i])**2 for i in range(3))) < 0.1:
-            if abs(yaw_difference) < 0.05:
+            if abs(yaw_difference) < 0.15:
                 target = next(waypoints_iter, target)
 
         rate.sleep()

--- a/src/LowLevelMotionController.cpp
+++ b/src/LowLevelMotionController.cpp
@@ -43,7 +43,7 @@ void limitUavCommand(QuadTwistRequestLimiter& limiter, iarc7_msgs::OrientationTh
     uav_command.data.yaw     = uav_twist.angular.z;
 }
 
-void getPidParams(ros::NodeHandle& nh, double throttle_pid[5], double pitch_pid[5], double roll_pid[5])
+void getPidParams(ros::NodeHandle& nh, double throttle_pid[5], double pitch_pid[5], double roll_pid[5], double yaw_pid[5])
 {
     // Throttle PID settings retrieve
     nh.param("throttle_p", throttle_pid[0], 0.0);
@@ -65,6 +65,13 @@ void getPidParams(ros::NodeHandle& nh, double throttle_pid[5], double pitch_pid[
     nh.param("roll_d", roll_pid[2], 0.0);
     nh.param("roll_accumulator_max", roll_pid[3], 0.0);
     nh.param("roll_accumulator_min", roll_pid[4], 0.0);
+
+    // Yaw PID settings retrieve
+    nh.param("yaw_p", yaw_pid[0], 0.0);
+    nh.param("yaw_i", yaw_pid[1], 0.0);
+    nh.param("yaw_d", yaw_pid[2], 0.0);
+    nh.param("yaw_accumulator_max", yaw_pid[3], 0.0);
+    nh.param("yaw_accumulator_min", yaw_pid[4], 0.0);
 }
 
 void getUavCommandParams(ros::NodeHandle& nh, Twist& min,  Twist& max,  Twist& max_rate)
@@ -102,9 +109,10 @@ int main(int argc, char **argv)
     double throttle_pid[5];
     double pitch_pid[5];
     double roll_pid[5];
-    getPidParams(param_nh, throttle_pid, pitch_pid,roll_pid);
+    double yaw_pid[5];
+    getPidParams(param_nh, throttle_pid, pitch_pid, roll_pid, yaw_pid);
 
-    QuadVelocityController quadController(throttle_pid, pitch_pid, roll_pid);
+    QuadVelocityController quadController(throttle_pid, pitch_pid, roll_pid, yaw_pid);
 
     AccelerationPlanner<QuadVelocityController> accelerationPlanner(nh, quadController);
 

--- a/src/QuadVelocityController.cpp
+++ b/src/QuadVelocityController.cpp
@@ -10,21 +10,23 @@
 #include "iarc7_motion/QuadVelocityController.hpp"
 
 // ROS message headers
-#include "geometry_msgs/Vector3Stamped.h"
 
 using namespace Iarc7Motion;
 
 QuadVelocityController::QuadVelocityController(double thrust_pid[5],
                                                double pitch_pid[5],
-                                               double roll_pid[5]) :
+                                               double roll_pid[5],
+                                               double yaw_pid[5]) :
 tfBuffer_(),
 tfListener_(tfBuffer_),
 throttle_pid_(thrust_pid[0], thrust_pid[1], thrust_pid[2], thrust_pid[3], thrust_pid[4]),
 pitch_pid_(pitch_pid[0], pitch_pid[1], pitch_pid[2], pitch_pid[3], pitch_pid[4]),
 roll_pid_(roll_pid[0], roll_pid[1], roll_pid[2], roll_pid[3], roll_pid[4]),
-yaw_pid_(0.0, 0.0, 0.0, 0.0, 0.0),
+yaw_pid_(yaw_pid[0], yaw_pid[1], yaw_pid[2], yaw_pid[3], yaw_pid[4]),
 hover_throttle_(58.0),
-ran_once_(false)
+ran_once_(false),
+last_transform_stamped_(),
+last_yaw_(0.0)
 {
 
 }
@@ -33,16 +35,20 @@ ran_once_(false)
 void QuadVelocityController::setTargetVelocity(geometry_msgs::Twist twist)
 {
     throttle_pid_.setSetpoint(twist.linear.z);
-    pitch_pid_.setSetpoint(twist.linear.x);
-    roll_pid_.setSetpoint(-twist.linear.y);
     yaw_pid_.setSetpoint(twist.angular.z);
+
+    // Pitch and roll velocities are transformed to vectors that pitch and roll can respond to
+    pitch_pid_.setSetpoint(twist.linear.x * std::cos(last_yaw_) + twist.linear.y * std::sin(last_yaw_));
+
+    // Invert roll because a positive y velocity means a negative roll by the right hand rule
+    roll_pid_.setSetpoint(-(twist.linear.x * -std::sin(last_yaw_) + twist.linear.y * std::cos(last_yaw_)));
 }
 
 // Needs to be called at regular intervals in order to keep catching the latest velocities.
 bool QuadVelocityController::update(const ros::Time& time,
                                     iarc7_msgs::OrientationThrottleStamped& uav_command)
 {
-    geometry_msgs::Vector3 velocities;
+    geometry_msgs::Twist velocities;
     getVelocities(velocities);
 
     // Update all the PID loops
@@ -51,25 +57,25 @@ bool QuadVelocityController::update(const ros::Time& time,
     double roll_output;
     double yaw_output;
 
-    bool success = throttle_pid_.update(velocities.z, time, throttle_output);
+    bool success = throttle_pid_.update(velocities.linear.z, time, throttle_output);
     if (!success) {
         ROS_WARN("Throttle PID update failed in QuadVelocityController::update");
         return false;
     }
 
-    success = pitch_pid_.update(velocities.x, time, pitch_output);
+    success = pitch_pid_.update(velocities.linear.x, time, pitch_output);
     if (!success) {
         ROS_WARN("Pitch PID update failed in QuadVelocityController::update");
         return false;
     }
 
-    success = roll_pid_.update(-velocities.y, time, roll_output);
+    success = roll_pid_.update(-velocities.linear.y, time, roll_output);
     if (!success) {
         ROS_WARN("Roll PID update failed in QuadVelocityController::update");
         return false;
     }
 
-    success = yaw_pid_.update(velocities.y, time, yaw_output);
+    success = yaw_pid_.update(velocities.angular.z, time, yaw_output);
     if (!success) {
         ROS_WARN("Yaw PID update failed in QuadVelocityController::update");
         return false;
@@ -83,15 +89,15 @@ bool QuadVelocityController::update(const ros::Time& time,
     uav_command.data.yaw = yaw_output;
 
     // Print the velocity and throttle information
-    ROS_DEBUG("Vz:       %f Vx:    %f Vy:   %f", velocities.z, velocities.x, velocities.y);
-    ROS_DEBUG("Throttle: %f Pitch: %f Roll: %f Yaw: %f", uav_command.throttle, uav_command.data.pitch, uav_command.data.roll, uav_command.data.yaw);
+    ROS_INFO("Vz:       %f Vx:    %f Vy:   %f Vyaw: %f", velocities.linear.z, velocities.linear.x, velocities.linear.y, velocities.angular.z);
+    ROS_INFO("Throttle: %f Pitch: %f Roll: %f Yaw:  %f", uav_command.throttle, uav_command.data.pitch, uav_command.data.roll, uav_command.data.yaw);
 
     return true;
 }
 
 // Waits for the next transform to come in, returns true if velocities are valid
 // Has to receive two transforms within the timeout period to consider the velocity valid
-bool QuadVelocityController::getVelocities(geometry_msgs::Vector3& return_velocities)
+bool QuadVelocityController::getVelocities(geometry_msgs::Twist& return_velocities)
 {
     // Can be set to mark a velocity reading invalid
     bool velocities_valid{true};
@@ -104,13 +110,13 @@ bool QuadVelocityController::getVelocities(geometry_msgs::Vector3& return_veloci
 
     // Check if we already have a velocity at this time
     if (time == last_velocity_stamped_.header.stamp) {
-        return_velocities = last_velocity_stamped_.vector;
+        return_velocities = last_velocity_stamped_.twist;
         return true;
     }
 
     try{
-        transformStamped = tfBuffer_.lookupTransform("map", "level_quad", time, ros::Duration(MAX_TRANSFORM_WAIT_SECONDS));
-
+        transformStamped = tfBuffer_.lookupTransform("map", "quad", time, ros::Duration(MAX_TRANSFORM_WAIT_SECONDS));
+        double current_yaw{0.0};
         if(ran_once_)
         {
             // Get the time between the two transforms
@@ -122,19 +128,46 @@ bool QuadVelocityController::getVelocities(geometry_msgs::Vector3& return_veloci
                 velocities_valid = false;
             }
 
-            // Get the transforms with the stamps for readability
+            // Get the transforms without the stamps for readability
             geometry_msgs::Transform& transform = transformStamped.transform;
             geometry_msgs::Transform& oldTransform = last_transform_stamped_.transform;
 
-            // Calculate x, y, and z velocity
-            double delta = delta_seconds.toSec();
+            // Get the yaw (z axis) rotation from the quanternion
+            double ysqr = transform.rotation.y * transform.rotation.y;
+            double t3 = 2.0f * (transform.rotation.w * transform.rotation.z + transform.rotation.x * transform.rotation.y);
+            double t4 = 1.0f - 2.0f * (ysqr + transform.rotation.z * transform.rotation.z);  
+            current_yaw = std::atan2(t3, t4);
 
-            return_velocities.x = (transform.translation.x - oldTransform.translation.x) / delta;
-            return_velocities.y = (transform.translation.y - oldTransform.translation.y) / delta;
-            return_velocities.z = (transform.translation.z - oldTransform.translation.z) / delta;
+            // Calculate x, y, and z velocity
+            // X and Y are transformed using the current yaw heading to velocities that the pitch and roll can respond to directly
+            double delta = delta_seconds.toSec();
+            double world_x_vel = ((transform.translation.x - oldTransform.translation.x) / delta);
+            double world_y_vel = ((transform.translation.y - oldTransform.translation.y) / delta);
+            return_velocities.linear.x = world_x_vel * std::cos(current_yaw) + world_y_vel * std::sin(current_yaw);
+            return_velocities.linear.y = world_x_vel * -std::sin(current_yaw) + world_y_vel * std::cos(current_yaw);
+
+            return_velocities.linear.z = (transform.translation.z - oldTransform.translation.z) / delta;
+
+            double yaw_difference = current_yaw - last_yaw_;
+
+            // The next two if statements handle if the yaw_difference is large due to gimbal lock
+            // Assumes that we don't have a yaw_difference more than 2pi. We won't since we get all the angles
+            // from an atan2 which only return -pi to pi
+            // Also assumes that we won't have a rotation difference more than pi
+            if(yaw_difference > 3.14159)
+            {
+                yaw_difference = yaw_difference - 2 * 3.14159;
+            }
+
+            if(yaw_difference < -3.14159)
+            {
+                yaw_difference = yaw_difference + 2 * 3.14159;
+            }
+
+            return_velocities.angular.z = yaw_difference / delta;
 
             // Store this as the last valid velocity
-            last_velocity_stamped_.vector = return_velocities;
+            last_velocity_stamped_.twist = return_velocities;
             last_velocity_stamped_.header.stamp = time;
         }
         else
@@ -144,6 +177,7 @@ bool QuadVelocityController::getVelocities(geometry_msgs::Vector3& return_veloci
         }
 
         last_transform_stamped_ = transformStamped;
+        last_yaw_ = current_yaw;
     }
     catch (tf2::TransformException& ex){
         ROS_ERROR("Could not transform map to level_quad: %s",ex.what());

--- a/src/QuadVelocityController.cpp
+++ b/src/QuadVelocityController.cpp
@@ -154,14 +154,14 @@ bool QuadVelocityController::getVelocities(geometry_msgs::Twist& return_velociti
             // Assumes that we don't have a yaw_difference more than 2pi. We won't since we get all the angles
             // from an atan2 which only return -pi to pi
             // Also assumes that we won't have a rotation difference more than pi
-            if(yaw_difference > 3.14159)
+            if(yaw_difference > M_PI)
             {
-                yaw_difference = yaw_difference - 2 * 3.14159;
+                yaw_difference = yaw_difference - 2 * M_PI;
             }
 
-            if(yaw_difference < -3.14159)
+            if(yaw_difference < -M_PI)
             {
-                yaw_difference = yaw_difference + 2 * 3.14159;
+                yaw_difference = yaw_difference + 2 * M_PI;
             }
 
             return_velocities.angular.z = yaw_difference / delta;

--- a/test/AccelerationPlannerTest.cpp
+++ b/test/AccelerationPlannerTest.cpp
@@ -13,7 +13,7 @@ namespace Iarc7Motion
         typedef Iarc7Motion::AccelerationPlanner<Iarc7Motion::QuadVelocityController> Planner;
 
         ros::Time::init();
-        ros::Time current_time = ros::Time::now();
+        ros::Time current_time(ros::Time::now());
 
         Iarc7Motion::TwistStampedArray twists;
         // Create an array of 10 twists
@@ -54,7 +54,7 @@ namespace Iarc7Motion
         typedef Iarc7Motion::AccelerationPlanner<Iarc7Motion::QuadVelocityController> Planner;
 
         ros::Time::init();
-        ros::Time current_time(0.0);
+        ros::Time current_time(ros::Time::now());
 
         Iarc7Motion::TwistStampedArray twists;
         Iarc7Motion::TwistStampedArray twists_append;


### PR DESCRIPTION
Support simultaneous yaw and translation, refactor QuadVelocity controller to use twists.

The waypoint tester was expanded to test this functionality.

Currently yaw calculations are done using the angle around the z axis. Using Quanternions in the future is an idea for a future rewrite.