### PR TITLE
Add separate tf timout on startup

### DIFF
--- a/include/iarc7_motion/QuadVelocityController.hpp
+++ b/include/iarc7_motion/QuadVelocityController.hpp
@@ -90,6 +90,7 @@ namespace Iarc7Motion
         // Makes sure that we have a lastTransformStamped before returning a valid velocity
         bool wait_for_velocities_ran_once_;
 
+        static constexpr double INITIAL_TRANSFORM_WAIT_SECONDS{10.0};
         static constexpr double MAX_TRANSFORM_WAIT_SECONDS{1.0};
         static constexpr double MAX_TRANSFORM_DIFFERENCE_SECONDS{0.3};
     };

--- a/src/QuadVelocityController.cpp
+++ b/src/QuadVelocityController.cpp
@@ -148,7 +148,11 @@ bool QuadVelocityController::waitForTransform(geometry_msgs::TransformStamped& t
         while (ros::ok())
         {
             // Check for timing out, return failure if so.
-            if (ros::Time::now() > time_at_start + ros::Duration(MAX_TRANSFORM_WAIT_SECONDS))
+            ros::Duration timeout = wait_for_velocities_ran_once_ ?
+                                    ros::Duration(MAX_TRANSFORM_WAIT_SECONDS) :
+                                    ros::Duration(INITIAL_TRANSFORM_WAIT_SECONDS);
+
+            if (ros::Time::now() > time_at_start + timeout)
             {
                 ROS_ERROR_STREAM("Transform timed out ("
                                  << "current time: " << ros::Time::now() << ", "


### PR DESCRIPTION
The system takes some time to come up, so we should allow more time on the first attempt to retrieve a transform.  In the future, we could check that the transform is available and not start the loop until it is.