### PR TITLE
Support landing detector instead of contact switches

### DIFF
--- a/include/iarc7_motion/LandPlanner.hpp
+++ b/include/iarc7_motion/LandPlanner.hpp
@@ -15,8 +15,8 @@
 #include "ros_utils/SafeTransformWrapper.hpp"
 
 // ROS message headers
+#include "iarc7_msgs/BoolStamped.h"
 #include "geometry_msgs/TwistStamped.h"
-#include "iarc7_msgs/LandingGearContactsStamped.h"
 #include "iarc7_msgs/Arm.h"
 
 namespace Iarc7Motion
@@ -57,17 +57,14 @@ public:
 
 private:
     // Handles incoming landing gear messages
-    void processLandingGearMessage(
-        const iarc7_msgs::LandingGearContactsStamped::ConstPtr& message);
+    void processLandingDetectedMessage(
+        const iarc7_msgs::BoolStamped::ConstPtr& message);
 
-    static bool allPressed(const iarc7_msgs::LandingGearContactsStamped& msg);
-    static bool anyPressed(const iarc7_msgs::LandingGearContactsStamped& msg);
+    iarc7_msgs::BoolStamped landing_detected_message_;
 
-    iarc7_msgs::LandingGearContactsStamped landing_gear_message_;
+    ros::Subscriber landing_detected_subscriber_;
 
-    ros::Subscriber landing_gear_subscriber_;
-
-    bool landing_gear_message_received_;
+    bool landing_detected_message_received_;
 
     ros_utils::SafeTransformWrapper transform_wrapper_;
 

--- a/include/iarc7_motion/TakeoffController.hpp
+++ b/include/iarc7_motion/TakeoffController.hpp
@@ -17,8 +17,8 @@
 #include "iarc7_motion/ThrustModel.hpp"
 
 // ROS message headers
+#include "iarc7_msgs/BoolStamped.h"
 #include "iarc7_msgs/Float64Stamped.h"
-#include "iarc7_msgs/LandingGearContactsStamped.h"
 #include "iarc7_msgs/OrientationThrottleStamped.h"
 #include "iarc7_msgs/Arm.h"
 
@@ -65,17 +65,15 @@ public:
     const ThrustModel& getThrustModel() const;
 
 private:
-    // Handles incoming landing gear messages
-    void processLandingGearMessage(
-        const iarc7_msgs::LandingGearContactsStamped::ConstPtr& message);
+    // Handles incoming landing detection messages
+    void processLandingDetectedMessage(
+        const iarc7_msgs::BoolStamped::ConstPtr& message);
 
-    static bool allPressed(const iarc7_msgs::LandingGearContactsStamped& msg);
+    iarc7_msgs::BoolStamped landing_detected_message_;
 
-    iarc7_msgs::LandingGearContactsStamped landing_gear_message_;
+    ros::Subscriber landing_detected_subscriber_;
 
-    ros::Subscriber landing_gear_subscriber_;
-
-    bool landing_gear_message_received_;
+    bool landing_detected_message_received_;
 
     ros_utils::SafeTransformWrapper transform_wrapper_;
 

--- a/src/LandPlanner.cpp
+++ b/src/LandPlanner.cpp
@@ -66,7 +66,7 @@ bool LandPlanner::prepareForTakeover(const ros::Time& time)
         return false;
     }
 
-    if(!landing_detected_message_.data) {
+    if(landing_detected_message_.data) {
         ROS_ERROR("Tried to reset the LandPlanner while being on the ground");
         return false;
     }

--- a/src/LandPlanner.cpp
+++ b/src/LandPlanner.cpp
@@ -18,7 +18,10 @@ using namespace Iarc7Motion;
 LandPlanner::LandPlanner(
         ros::NodeHandle& nh,
         ros::NodeHandle& private_nh)
-    : transform_wrapper_(),
+    : landing_detected_message_(),
+      landing_detected_subscriber_(),
+      landing_detected_message_received_(false),
+      transform_wrapper_(),
       state_(LandState::DONE),
       requested_z_vel_(0.0),
       descend_acceleration_(ros_utils::ParamUtils::getParam<double>(
@@ -48,9 +51,9 @@ LandPlanner::LandPlanner(
               "update_timeout")),
       uav_arm_client_(nh.serviceClient<iarc7_msgs::Arm>("uav_arm"))
 {
-    landing_gear_subscriber_ = nh.subscribe("landing_gear_contact_switches",
+    landing_detected_subscriber_ = nh.subscribe("landing_detected",
                                  100,
-                                 &LandPlanner::processLandingGearMessage,
+                                 &LandPlanner::processLandingDetectedMessage,
                                  this);
 }
 
@@ -63,7 +66,7 @@ bool LandPlanner::prepareForTakeover(const ros::Time& time)
         return false;
     }
 
-    if(allPressed(landing_gear_message_)) {
+    if(!landing_detected_message_.data) {
         ROS_ERROR("Tried to reset the LandPlanner while being on the ground");
         return false;
     }
@@ -118,7 +121,7 @@ bool LandPlanner::getTargetTwist(const ros::Time& time,
             ROS_ERROR("Land sequence failed, quad started going up again");
             return false;
         }
-        else if(anyPressed(landing_gear_message_)) {
+        else if(landing_detected_message_.data) {
             // Sending disarm request to fc_comms
             iarc7_msgs::Arm srv;
             srv.request.data = false;
@@ -171,19 +174,19 @@ bool LandPlanner::waitUntilReady()
 
     const ros::Time start_time = ros::Time::now();
     while (ros::ok()
-           && !landing_gear_message_received_
+           && !landing_detected_message_received_
            && ros::Time::now() < start_time + startup_timeout_) {
         ros::spinOnce();
         ros::Duration(0.005).sleep();
     }
 
-    if (!landing_gear_message_received_) {
+    if (!landing_detected_message_received_) {
         ROS_ERROR_STREAM("LandPlanner failed to fetch initial switch message");
         return false;
     }
 
     // This time is just used to calculate any ramping that needs to be done.
-    last_update_time_ = landing_gear_message_.header.stamp;
+    last_update_time_ = landing_detected_message_.header.stamp;
     return true;
 }
 
@@ -192,19 +195,9 @@ bool LandPlanner::isDone()
   return (state_ == LandState::DONE);
 }
 
-void LandPlanner::processLandingGearMessage(
-    const iarc7_msgs::LandingGearContactsStamped::ConstPtr& message)
+void LandPlanner::processLandingDetectedMessage(
+    const iarc7_msgs::BoolStamped::ConstPtr& message)
 {
-    landing_gear_message_received_ = true;
-    landing_gear_message_ = *message;
-}
-
-bool LandPlanner::allPressed(const iarc7_msgs::LandingGearContactsStamped& msg)
-{
-    return msg.front && msg.back && msg.left && msg.right;
-}
-
-bool LandPlanner::anyPressed(const iarc7_msgs::LandingGearContactsStamped& msg)
-{
-    return msg.front || msg.back || msg.left || msg.right;
+    landing_detected_message_received_ = true;
+    landing_detected_message_ = *message;
 }

--- a/src/iarc7_motion/iarc_tasks/block_roomba_task.py
+++ b/src/iarc7_motion/iarc_tasks/block_roomba_task.py
@@ -17,7 +17,7 @@ from nav_msgs.msg import Odometry
 from task_utilities.acceleration_limiter import AccelerationLimiter
 
 from iarc7_msgs.msg import OdometryArray
-from iarc7_msgs.msg import LandingGearContactsStamped
+from iarc7_msgs.msg import BoolStamped
 
 from .abstract_task import AbstractTask
 from iarc_tasks.task_states import (TaskRunning,
@@ -51,7 +51,7 @@ class BlockRoombaTask(object, AbstractTask):
 
         self._drone_odometry = None
         self._canceled = False
-        self._switch_message = None
+        self._landed_message = None
         self._last_update_time = None
         self._current_velocity = None
         self._transition = None
@@ -61,9 +61,9 @@ class BlockRoombaTask(object, AbstractTask):
 
         self._lock = threading.RLock()
 
-        self._contact_switches_sub = rospy.Subscriber(
-            'landing_gear_contact_switches', LandingGearContactsStamped, 
-            self._receive_switch_status)
+        self._landing_message_sub = rospy.Subscriber(
+            'landing_detected', BoolStamped, 
+            self._receive_landing_status)
 
         self._roomba_status_sub = rospy.Subscriber(
             'roombas', OdometryArray, 
@@ -94,9 +94,9 @@ class BlockRoombaTask(object, AbstractTask):
         with self._lock:
             self._roomba_array = data
 
-    def _receive_switch_status(self, data):
+    def _receive_landing_status(self, data):
         with self._lock:
-            self._switch_message = data
+            self._landed_message = data
 
     def _current_velocity_callback(self, data):
         with self._lock:
@@ -228,11 +228,10 @@ class BlockRoombaTask(object, AbstractTask):
         return True
 
     def _on_ground(self):
-        if self._switch_message is None:
+        if self._landed_message is None:
             return False
         else: 
-            data = self._switch_message
-            return (data.front or data.back or data.left or data.right)
+            return self._landed_message.data
 
     def set_incoming_transition(self, transition):
         self._transition = transition


### PR DESCRIPTION
This doesn't touch the motion command coordinator which depends on landing gear switches for block and hit roomba.