### PR TITLE
Feed forward for height

### DIFF
--- a/include/iarc7_motion/ThrustModel.hpp
+++ b/include/iarc7_motion/ThrustModel.hpp
@@ -163,6 +163,7 @@ struct ThrustModel
                 top_thrusts.possible_thrusts[i].thrust); // End thrust top
 
             if(current_final_thrust >= desired_thrust) {
+
                 // Interpolate beteen voltages
                 // because the voltages for each index are the same
                 // in the top and bottom pair the bottom pair array is used
@@ -170,8 +171,20 @@ struct ThrustModel
                 voltage = linearInterpolate(desired_thrust,
                                              last_final_thrust,
                                              current_final_thrust,
-                                             bottom_thrusts.possible_thrusts[i].voltage,
-                                             bottom_thrusts.possible_thrusts[i+1].voltage);
+                                             bottom_thrusts.possible_thrusts[i-1].voltage,
+                                             bottom_thrusts.possible_thrusts[i].voltage);
+
+                ROS_DEBUG_STREAM("start_thrust " << start_thrust
+                                 << "\nbottom thrust start " << bottom_thrusts.start_thrust
+                                 << "\ntop_thrusts start " << top_thrusts.start_thrust
+                                 << "\nbottom thrusts possible " << bottom_thrusts.possible_thrusts[i].thrust
+                                 << "\ntop thrusts possible " << top_thrusts.possible_thrusts[i].thrust
+                                 << "\ndesired thrust " << desired_thrust
+                                 << "\nlast final thrust " << last_final_thrust
+                                 << "\ncurrent final thrust " << current_final_thrust
+                                 << "\nvoltage low " << bottom_thrusts.possible_thrusts[i].voltage
+                                 << "\nvoltage high " << bottom_thrusts.possible_thrusts[i+1].voltage);
+
                 break;
             }
             last_final_thrust = current_final_thrust;

--- a/param/low_level_motion_crazyflie.yaml
+++ b/param/low_level_motion_crazyflie.yaml
@@ -1,17 +1,17 @@
 # PID values are positive for forward acting PID loops and negative for
 # reverse acting PID loops. P, I, and D should all be the same sign.
-throttle_p: 7.5
-throttle_i: 0.8
-throttle_d: 5.0
+throttle_p: 8.0
+throttle_i: 1.0
+throttle_d: 3.0
 throttle_accumulator_enable_threshold: 10.0
 throttle_accumulator_max: 5.0
 throttle_accumulator_min: -5.0
 
-model_mass: 0.020
+model_mass: 0.030
 
 # Thrust levels are in m/s^2
 min_thrust: 6.0
-max_thrust: 11.8
+max_thrust: 20.0
 
 battery_timeout: 0.5
 

--- a/param/low_level_motion_sim.yaml
+++ b/param/low_level_motion_sim.yaml
@@ -1,8 +1,8 @@
 # PID values are positive for forward acting PID loops and negative for
 # reverse acting PID loops. P, I, and D should all be the same sign.
-throttle_p: 10.0
+throttle_p: 6.0
 throttle_i: 0.5
-throttle_d: 2.0
+throttle_d: 0.1
 throttle_accumulator_max: 0.5
 throttle_accumulator_min: -0.5
 throttle_accumulator_enable_threshold: 10.0

--- a/param/motion_command_coordinator.yaml
+++ b/param/motion_command_coordinator.yaml
@@ -16,6 +16,6 @@ task_timeout_deceleration_time: 1.0
 # Resolution to generate linear motion profiles with
 linear_motion_profile_timestep: 0.020
 # Acceleration to use for linear motion profile generation
-linear_motion_profile_acceleration: 1.0
+linear_motion_profile_acceleration: 3.0
 # Length of time to generate a linear motion profile for
 linear_motion_profile_duration: 0.2

--- a/scripts/thrust_model_v2/Dynamic/DynamicModelData/SunnyskyDynamic/unknown_10_45_dynamic_r2.txt.output.yaml
+++ b/scripts/thrust_model_v2/Dynamic/DynamicModelData/SunnyskyDynamic/unknown_10_45_dynamic_r2.txt.output.yaml
@@ -1,3 +1,5 @@
+# Generated on 2018-04-01 16:47:39.565546
+
 response_lag: 0.02997165074407926
 small_thrust_epsilon: 0.008
 thrust_to_voltage: [16.349891243165725, -29.722915017680208, 25.612765123529435, 0.05935972046598993]
@@ -428,3 +430,4 @@ voltage_to_jerk:
   timestep: 0.02
   voltage_max: 11.5
   voltage_min: 0.0
+

--- a/scripts/thrust_model_v2/Dynamic/generate_thrust_model.py
+++ b/scripts/thrust_model_v2/Dynamic/generate_thrust_model.py
@@ -363,7 +363,6 @@ def plot_all_responses(ramps,
         start_thrust = ramps[i].get_start_thrust()
         end_thrust = ramps[i].get_end_thrust()
         ax1 = plt.subplot(n, m, i + 1)
-        ax2 = ax1.twinx()
 
         if filtered_getter is not None:
             (filtered_thrust_times, filtered_thrusts) = filtered_getter(
@@ -391,6 +390,7 @@ def plot_all_responses(ramps,
             ax3.axhline(y=ramps[i].start_voltage, linewidth=1, color='c')
             ax3.axhline(y=ramps[i].end_voltage, linewidth=1, color='c')
         else:
+            ax2 = ax1.twinx()
             ax2.plot(throttle_times, throttles, color='r')
 
 
@@ -668,7 +668,7 @@ if __name__ == "__main__":
     # plot_groups(ramps, group_plotter=plot_all_voltages)
 
     # plot_groups(ramps, group_plotter=plot_all_fft)
-    # plot_groups(ramps, group_plotter=plot_all_voltages_filtered)
+    plot_groups(ramps, group_plotter=plot_all_voltages_filtered)
 
     response_lag = calculate_response_lags(ramps)
     voltage_to_thrust_poly, thrust_to_voltage_poly = create_voltage_to_thrust(

--- a/src/LandPlanner.cpp
+++ b/src/LandPlanner.cpp
@@ -106,7 +106,7 @@ bool LandPlanner::getTargetMotionPoint(const ros::Time& time,
 
     if(state_ == LandState::DESCEND)
     {
-        actual_descend_rate_ = std::min(descend_rate_,
+        actual_descend_rate_ = std::max(descend_rate_,
                                         actual_descend_rate_
                                         + (descend_acceleration_
                                         * (time - last_update_time_).toSec()));
@@ -147,6 +147,10 @@ bool LandPlanner::getTargetMotionPoint(const ros::Time& time,
     motion_point.header.stamp = time;
 
     motion_point.motion_point.pose.position.z = requested_height_;
+
+    if(actual_descend_rate_ > descend_rate_) {
+        motion_point.motion_point.accel.linear.z = descend_acceleration_;
+    }
 
     last_update_time_ = time;
     return true;

--- a/src/QuadVelocityController.cpp
+++ b/src/QuadVelocityController.cpp
@@ -285,8 +285,8 @@ bool QuadVelocityController::update(const ros::Time& time,
     // oscillations from the PID's I term compensating for there needing to be
     // an average throttle value at 0 velocity in the z axis.
     ROS_DEBUG("Thrust: %f, Voltage: %f, height: %f", hover_accel + tilt_accel + vertical_accel_output, voltage, col_height);
-    ROS_DEBUG("Hover: %f, Tilt: %f, Vertical %f", hover_accel, tilt_accel, vertical_accel_output);
-    double thrust_request = hover_accel + tilt_accel + vertical_accel_output;
+    ROS_DEBUG("Hover: %f, Tilt: %f, Vertical %f, Feedforward %f", hover_accel, tilt_accel, vertical_accel_output, setpoint_.motion_point.accel.linear.z);
+    double thrust_request = hover_accel + tilt_accel + vertical_accel_output + setpoint_.motion_point.accel.linear.z;
     uav_command.throttle = thrust_model_.voltageFromThrust(
             std::min(std::max(thrust_request, min_thrust_), max_thrust_),
             4,


### PR DESCRIPTION
Use feed forward for height hold which significantly increases performance.

This revealed scary bugs in the thrust model, linear motion profile generator, and some minor issues with the land planner. These were fixed.

Fixing these issues solved the height oscillation in the simulator and the crazyflie. Adding feed forward significantly reduced lag.